### PR TITLE
Add streaming to http-nano

### DIFF
--- a/nano-http.cabal
+++ b/nano-http.cabal
@@ -1,5 +1,5 @@
 name:                nano-http
-version:             0.1.2
+version:             0.1.3
 synopsis:            A lightweight wrapper around conduit
 description:         A lightweight wrapper around conduit
 homepage:            https://github.com/ralphmorton/nano-http#readme
@@ -24,6 +24,9 @@ library
                      , http-client >= 0.4.28
                      , http-types >= 0.9
                      , http-conduit >= 2.1.8
+                     , conduit >= 1.2.6.4
+                     , resourcet >= 1.1.7.3
+                     , json-stream >= 0.4.1.0
   default-language:    Haskell2010
 
 source-repository head

--- a/src/Network/HTTP/Nano.hs
+++ b/src/Network/HTTP/Nano.hs
@@ -8,6 +8,7 @@ module Network.HTTP.Nano(
     mkJSONData,
     http,
     http',
+    httpS,
     httpJSON,
     buildReq,
     addHeaders
@@ -22,13 +23,18 @@ import Control.Monad
 import Control.Monad.Except (MonadError, throwError)
 import Control.Monad.Reader (MonadReader)
 import Control.Monad.Trans (MonadIO, liftIO)
+import Control.Monad.Trans.Resource (MonadResource)
 import Data.Aeson (FromJSON, ToJSON, decode, encode)
 import Data.Bifunctor (bimap)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as BL
+import Data.Conduit (ResumableSource(..), Conduit, ($=+))
+import qualified Data.Conduit.List as CL
 import Data.String (fromString)
+import Data.JsonStream.Parser (value, parseByteString, Parser)
 import Network.HTTP.Client (HttpException(..))
 import Network.HTTP.Conduit hiding (http)
+import qualified Network.HTTP.Conduit as HC
 import Network.HTTP.Types.Status (statusCode, statusMessage)
 
 -- |Create an HTTP manager
@@ -46,6 +52,17 @@ http req = view httpManager >>= safeHTTP . httpLbs req >>= return . responseBody
 -- |Perform an HTTP request, ignoring the response
 http' :: (MonadError e m, MonadReader r m, AsHttpError e, HasHttpCfg r, MonadIO m) => Request -> m ()
 http' req = http req >> return ()
+
+httpS :: (MonadError e m, MonadReader r m, AsHttpError e, HasHttpCfg r, MonadResource m) => Request -> m (ResumableSource m B.ByteString)
+httpS req = view httpManager >>= HC.http req >>= return . responseBody
+
+httpSJSON :: (MonadError e m, MonadReader r m, AsHttpError e, HasHttpCfg r, MonadResource m, FromJSON a) => Request -> m (ResumableSource m a)
+httpSJSON req = do
+    src <- httpS req 
+    return $ src $=+ jsonConduit 
+
+jsonConduit :: (MonadError e m, MonadReader r m, AsHttpError e, HasHttpCfg r, MonadResource m, FromJSON a) => Conduit B.ByteString m a
+jsonConduit = CL.mapFoldable (parseByteString value)
 
 -- |Perform an HTTP request, attempting to parse the response as JSON
 httpJSON :: (MonadError e m, MonadReader r m, AsHttpError e, HasHttpCfg r, MonadIO m, FromJSON b) => Request -> m b

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,16 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.14
+resolver: lts-6.11
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- json-stream-0.4.1.0
+- text-1.2.2.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
@ralphmorton This introduces a few bits of conduit & allows for creating a resumable source of some type `a` w/o buffering the entire thing into memory. 
